### PR TITLE
Audio fix, invisible cursor, privileged initial event, and Black formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+whitney.yaml
+frame/__pycache__/
+frame/server/__pycache__/

--- a/frame/frame.py
+++ b/frame/frame.py
@@ -338,7 +338,12 @@ def load_events(path, events_list):
         first.do_run()
 
         events_list.append(first)
-        logging.info("Initial video configured: " + initial["name"] + ". Plays until interrupted..")
+        logging.info(
+            "Initial video configured: "
+            + initial["name"]
+            + ". Plays until interrupted.."
+        )
+
 
 def tick(events):
     event_logging.info("Tick")

--- a/frame/frame.py
+++ b/frame/frame.py
@@ -327,17 +327,18 @@ def load_events(path, events_list):
         events_list.append(e)
 
     initial = settings.get("initial")
-    first = create_event(frame, initial)
-    # NOTE: this double initialize is necessary to set appropriately at both the
-    # Event level and at the PlayVideo level. It's a hack to create an Event that
-    # bypasses initialization via schedule, but retains the lifecycle etc.
-    first.initialize()
-    first.do_initialize()
-    first.run()
-    first.do_run()
+    if initial:
+        first = create_event(frame, initial)
+        # NOTE: this double initialize is necessary to set appropriately at both the
+        # Event level and at the PlayVideo level. It's a hack to create an Event that
+        # bypasses initialization via schedule, but retains the lifecycle etc.
+        first.initialize()
+        first.do_initialize()
+        first.run()
+        first.do_run()
 
-    events_list.append(first)
-    logging.info("Initial video configured: " + initial["name"] + ". Plays until interrupted..")
+        events_list.append(first)
+        logging.info("Initial video configured: " + initial["name"] + ". Plays until interrupted..")
 
 def tick(events):
     event_logging.info("Tick")

--- a/frame/frame.py
+++ b/frame/frame.py
@@ -7,7 +7,7 @@ import time
 import yaml
 import logging, logging.handlers
 import argparse
-from . import server
+import server
 
 from queue import Queue
 

--- a/frame/frame.py
+++ b/frame/frame.py
@@ -157,6 +157,13 @@ class DisplayEvent(Event):
     def do_stop(self):
         self.frame.pop(self.widget)
 
+    def tick(self):
+        super().tick()
+        if self.state == "running":
+            cur_widget = self.frame.currentWidget()
+            if cur_widget is not self.widget:
+                self.stop()
+
 class Frame(QStackedWidget):
     def __init__(self, parent, settings):
         super().__init__(parent)
@@ -199,6 +206,7 @@ class Frame(QStackedWidget):
 
     def set_current(self):
         self.setCurrentWidget(self.stack[-1])
+
 
 class PlayVideo(DisplayEvent):
     def __init__(self, frame, settings):

--- a/frame/frame.py
+++ b/frame/frame.py
@@ -345,6 +345,7 @@ def main():
     app = server.run_server(event_logging_queue, events)
 
     application = QApplication(sys.argv)
+    application.setOverrideCursor(Qt.BlankCursor)
 
     load_events(args.settings_yaml, events)
 

--- a/frame/frame.py
+++ b/frame/frame.py
@@ -43,7 +43,7 @@ class Event:
         self.schedule_string = settings.get('schedule')
         self.job = string_to_job(settings.get('schedule'))
         self.cancel_on_error = settings.get('cancel_on_error', False)
-        
+
         if self.job:
             if self.tags:
                 self.job.tags(*self.tags)
@@ -53,7 +53,7 @@ class Event:
 
     def __init_logging__(self, settings):
         self.logging = logging.getLogger('frame.event.%s' % str(settings.get('name')))
-    
+
     def protect(self, func, *args, **kwargs):
         try:
             self.logging.debug("Running '%s.%s()'" % (
@@ -99,7 +99,7 @@ class Event:
         if self.state == 'running':
             if self.protect(self.do_stop):
                 self.state = 'initialized'
- 
+
     def reset(self):
         self.stop()
         if self.protect(self.do_reset):
@@ -167,8 +167,8 @@ class Frame(QStackedWidget):
         self.setAutoFillBackground(True)
         self.background_color = settings.get('background_color', [0.0, 0.0, 0.0])
         self.background_color = QColor(
-            self.background_color[0] * 255, 
-            self.background_color[1] * 255, 
+            self.background_color[0] * 255,
+            self.background_color[1] * 255,
             self.background_color[2] * 255,
             255)
         self.set_background_color(self.background_color)
@@ -238,7 +238,7 @@ class PlayVideo(DisplayEvent):
         self.player.setVideoOutput(self.video)
         self.player.setVolume(self.volume)
         self.player.setPlaybackRate(self.playback_rate)
-    
+
     def do_run(self):
         super().do_run()
         self.player.setPlaylist(self.playlist)

--- a/frame/server/__init__.py
+++ b/frame/server/__init__.py
@@ -1,4 +1,5 @@
 from . import server
 
+
 def run_server(*args, **kwargs):
     return server.run_server(*args, **kwargs)

--- a/frame/server/server.py
+++ b/frame/server/server.py
@@ -1,5 +1,5 @@
 import os.path
-import logging 
+import logging
 import json
 import datetime
 import asyncio
@@ -16,9 +16,9 @@ event_logging_listener = None
 
 class Server(tornado.web.Application):
     def __init__(self, event_list, event_logging_listener):
-        handlers = [ 
-            (r"/events", Events, dict(event_list=event_list)), 
-            (r"/events/{name}", Events, dict(event_list=event_list)), 
+        handlers = [
+            (r"/events", Events, dict(event_list=event_list)),
+            (r"/events/{name}", Events, dict(event_list=event_list)),
             (r'/events/log', EventsLog, dict(listener=event_logging_listener))
         ]
         settings = {'debug': True}
@@ -47,7 +47,7 @@ class Events(tornado.web.RequestHandler):
             self.write(page)
         else:
             self.write('')
-    
+
 class EventsLog(tornado.web.RequestHandler):
     SUPPORTED_METHODS = ["GET"]
 
@@ -103,5 +103,5 @@ def run_server(event_logging_queue, event_list):
     t = Thread(target=start_server, args=())
     t.daemon = True
     t.start()
-    
+
     return {}

--- a/frame/server/server.py
+++ b/frame/server/server.py
@@ -14,19 +14,21 @@ from tornado.iostream import StreamClosedError
 
 event_logging_listener = None
 
+
 class Server(tornado.web.Application):
     def __init__(self, event_list, event_logging_listener):
         handlers = [
             (r"/events", Events, dict(event_list=event_list)),
             (r"/events/{name}", Events, dict(event_list=event_list)),
-            (r'/events/log', EventsLog, dict(listener=event_logging_listener))
+            (r"/events/log", EventsLog, dict(listener=event_logging_listener)),
         ]
-        settings = {'debug': True}
+        settings = {"debug": True}
         super().__init__(handlers, **settings)
 
     def run(self, port=8886):
         self.listen(port)
         tornado.ioloop.IOLoop.instance().start()
+
 
 class Events(tornado.web.RequestHandler):
     SUPPORTED_METHODS = ["GET"]
@@ -41,12 +43,11 @@ class Events(tornado.web.RequestHandler):
     def get(self, event_id=None):
         event_id = None
         if event_id == None:
-            page = self.template.generate(
-                events=self.event_list
-            )
+            page = self.template.generate(events=self.event_list)
             self.write(page)
         else:
-            self.write('')
+            self.write("")
+
 
 class EventsLog(tornado.web.RequestHandler):
     SUPPORTED_METHODS = ["GET"]
@@ -58,8 +59,8 @@ class EventsLog(tornado.web.RequestHandler):
         listener.handlers = listener.handlers = (self.handler,)
 
     def prepare(self):
-        self.set_header('content-type', 'text/event-stream')
-        self.set_header('cache-control', 'no-cache')
+        self.set_header("content-type", "text/event-stream")
+        self.set_header("cache-control", "no-cache")
 
     @gen.coroutine
     def get(self):
@@ -69,13 +70,15 @@ class EventsLog(tornado.web.RequestHandler):
             else:
                 record = self.queue.get(False)
                 record_json = {
-                    'time': datetime.datetime.fromtimestamp(record.created).strftime('%H:%M:%S'),
-                    'name': record.name,
-                    'level': record.levelname,
-                    'message': record.getMessage()
+                    "time": datetime.datetime.fromtimestamp(record.created).strftime(
+                        "%H:%M:%S"
+                    ),
+                    "name": record.name,
+                    "level": record.levelname,
+                    "message": record.getMessage(),
                 }
                 try:
-                    self.write('data: %s\n\n' % json.dumps(record_json))
+                    self.write("data: %s\n\n" % json.dumps(record_json))
                     yield self.flush()
                 except StreamClosedError:
                     return
@@ -84,6 +87,7 @@ class EventsLog(tornado.web.RequestHandler):
         handlers = list(self.listener.handlers)
         handlers.remove(self.handler)
         self.listener.handlers = tuple(handlers)
+
 
 def run_server(event_logging_queue, event_list):
     event_logging_listener = logging.handlers.QueueListener(event_logging_queue)
@@ -96,8 +100,8 @@ def run_server(event_logging_queue, event_list):
         asyncio.set_event_loop(asyncio.new_event_loop())
 
         ws = Server(
-            event_list=event_list,
-            event_logging_listener=event_logging_listener)
+            event_list=event_list, event_logging_listener=event_logging_listener
+        )
         ws.run()
 
     t = Thread(target=start_server, args=())

--- a/frame/settings.yaml
+++ b/frame/settings.yaml
@@ -1,3 +1,7 @@
+initial:
+  name: Test
+  type: PlayVideo
+  url: file:///Users/fsc/Downloads/jsjsjs.mp4
 events:
   test_video:
     name: Test

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,34 @@
 from setuptools import setup
 
-requirements = [
-    'pyqt5-sip',
-    'PyQt5',
-    'PyYAML==5.1',
-    'schedule==0.6.0',
-    'tornado>=6.0'
-]
+requirements = ["pyqt5-sip", "PyQt5", "PyYAML==5.1", "schedule==0.6.0", "tornado>=6.0"]
 
 test_requirements = [
-    'pytest',
-    'pytest-cov',
-    'pytest-faulthandler',
-    'pytest-mock',
-    'pytest-qt',
-    'pytest-xvfb',
+    "pytest",
+    "pytest-cov",
+    "pytest-faulthandler",
+    "pytest-mock",
+    "pytest-qt",
+    "pytest-xvfb",
 ]
 
 setup(
-    name='frame',
-    version='0.0.1',
+    name="frame",
+    version="0.0.1",
     description="A PyQt5 GUI application",
     author="scott carver",
-    author_email='scott@artificia.org',
-    url='https://github.com/scztt/frame',
-    packages=['frame', 'frame.images',
-              'frame.tests', 'frame.server'],
-    package_data={'frame.images': ['*.png']},
-    entry_points={
-        'console_scripts': [
-            'frame=frame.frame:main'
-        ]
-    },
+    author_email="scott@artificia.org",
+    url="https://github.com/scztt/frame",
+    packages=["frame", "frame.images", "frame.tests", "frame.server"],
+    package_data={"frame.images": ["*.png"]},
+    entry_points={"console_scripts": ["frame=frame.frame:main"]},
     install_requires=requirements,
     zip_safe=False,
-    keywords='frame',
+    keywords="frame",
     classifiers=[
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
     ],
-    test_suite='tests',
-    tests_require=test_requirements
+    test_suite="tests",
+    tests_require=test_requirements,
 )


### PR DESCRIPTION
* Audio currently bleeds across videos when a frame is pushed before the other has finished. I've added a conditional that calls `stop` on the event if it is not at the front in each tick.
* Sets the cursor invisible in the application so that it doesn't obscure the video.
* Adds a privileged initial event that runs with no schedule, until interrupted. Specified via YAML, see example `settings.yaml` for an example.
* Also have formatted existing python files with [black](https://github.com/ambv/black) to make things a little cleaner. (Not yet enforced in any way.)